### PR TITLE
svm: fix ci

### DIFF
--- a/.github/workflows/svm.yml
+++ b/.github/workflows/svm.yml
@@ -22,8 +22,11 @@ jobs:
         run: |
           ANCHOR_VERSION="$(awk '/anchor_version =/ { print substr($3, 2, length($3)-2) }' Anchor.toml)"
           echo "::set-output name=version::${ANCHOR_VERSION}"
-      - uses: evan-gray/anchor-test@24c04ecece7b484fa1218bab4318818b36436005
+      - uses: evan-gray/anchor-test@06370fbca011ee48b176211b8f858789d6c33282
+        env:
+          RUSTUP_TOOLCHAIN: nightly-2025-04-14
         with:
+          node-version: "22.16.0"
           anchor-version: "${{steps.anchor.outputs.version}}"
           solana-cli-version: "${{steps.solana.outputs.version}}"
           working-directory: "svm"


### PR DESCRIPTION
I was hesitant to change the anchor version since this is what was deployed and verified on Solana devnet, Solana mainnet, and Fogo testnet. Since the existing code works with `solana-verify build` I simply changed the rust version used by the action similar to suggestions made [here](https://solana.stackexchange.com/questions/21553/proc-macro2-source-file-method-not-found-in-span)