### PR TITLE
Bengt/adding tests

### DIFF
--- a/evm/src/ExecutorQuoterRouter.sol
+++ b/evm/src/ExecutorQuoterRouter.sol
@@ -33,6 +33,13 @@ contract ExecutorQuoterRouter is IExecutorQuoterRouter {
     error GovernanceExpired(uint64 expiryTime);
     error NotAnEvmAddress(bytes32);
 
+    struct ExecutionParams {
+        uint16 dstChain;
+        bytes32 dstAddr;
+        address refundAddr;
+        address quoterAddr;
+    }
+
     constructor(address _executor) {
         EXECUTOR = IExecutor(_executor);
         OUR_CHAIN = EXECUTOR.ourChain();
@@ -112,25 +119,34 @@ contract ExecutorQuoterRouter is IExecutorQuoterRouter {
         bytes calldata requestBytes,
         bytes calldata relayInstructions
     ) external payable {
-        IExecutorQuoter implementation = quoterContract[quoterAddr];
-        (uint256 requiredPayment, bytes32 payeeAddress, bytes32 quoteBody) =
-            implementation.requestExecutionQuote(dstChain, dstAddr, refundAddr, requestBytes, relayInstructions);
+        ExecutionParams memory params =
+            ExecutionParams({dstChain: dstChain, dstAddr: dstAddr, refundAddr: refundAddr, quoterAddr: quoterAddr});
+        _requestExecutionInternal(params, requestBytes, relayInstructions);
+    }
+
+    function _requestExecutionInternal(
+        ExecutionParams memory params,
+        bytes calldata requestBytes,
+        bytes calldata relayInstructions
+    ) private {
+        IExecutorQuoter implementation = quoterContract[params.quoterAddr];
+        (uint256 requiredPayment, bytes32 payeeAddress, bytes32 quoteBody) = implementation.requestExecutionQuote(
+            params.dstChain, params.dstAddr, params.refundAddr, requestBytes, relayInstructions
+        );
         if (msg.value < requiredPayment) {
             revert Underpaid(msg.value, requiredPayment);
         }
         if (msg.value > requiredPayment) {
-            (bool refundSuccessful,) = payable(refundAddr).call{value: msg.value - requiredPayment}("");
+            (bool refundSuccessful,) = payable(params.refundAddr).call{value: msg.value - requiredPayment}("");
             if (!refundSuccessful) {
-                revert RefundFailed(refundAddr);
+                revert RefundFailed(params.refundAddr);
             }
         }
+        bytes memory signedQuote = abi.encodePacked(
+            QUOTE_PREFIX, params.quoterAddr, payeeAddress, OUR_CHAIN, params.dstChain, EXPIRY_TIME, quoteBody
+        );
         EXECUTOR.requestExecution{value: requiredPayment}(
-            dstChain,
-            dstAddr,
-            refundAddr,
-            abi.encodePacked(QUOTE_PREFIX, quoterAddr, payeeAddress, OUR_CHAIN, dstChain, EXPIRY_TIME, quoteBody),
-            requestBytes,
-            relayInstructions
+            params.dstChain, params.dstAddr, params.refundAddr, signedQuote, requestBytes, relayInstructions
         );
         // this must emit a message in this function in order to verify off-chain that this contract generated the quote
         // the implementation is the only data available in this context that is not available from the executor event

--- a/evm/test/ExecutorQuoter.t.sol
+++ b/evm/test/ExecutorQuoter.t.sol
@@ -262,7 +262,9 @@ contract ExecutorQuoterTest is Test {
         emit log_named_uint("type(uint256).max", type(uint256).max);
         emit log_named_uint("type(uint128).max * 3", uint256(type(uint128).max) * 3);
 
-        assertEq(quote, 34028237372658580188214387669926038806136422910, "Quote should match expected value for max values");
+        assertEq(
+            quote, 34028237372658580188214387669926038806136422910, "Quote should match expected value for max values"
+        );
     }
 
     /// @notice Test quote calculation with zero prices (division by zero protection).

--- a/evm/test/ExecutorQuoter.t.sol
+++ b/evm/test/ExecutorQuoter.t.sol
@@ -96,4 +96,342 @@ contract ExecutorQuoterTest is Test {
             RelayInstructions.encodeGas(250000, 0)
         );
     }
+
+    // Error path tests
+
+    function test_chainInfoUpdate_invalidUpdater() public {
+        address notUpdater = address(0xdead);
+        vm.prank(notUpdater);
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoter.InvalidUpdater.selector, notUpdater, UPDATER));
+        executorQuoter.chainInfoUpdate(chainInfoUpdates);
+    }
+
+    function test_quoteUpdate_invalidUpdater() public {
+        address notUpdater = address(0xdead);
+        vm.prank(notUpdater);
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoter.InvalidUpdater.selector, notUpdater, UPDATER));
+        executorQuoter.quoteUpdate(updates);
+    }
+
+    function test_requestQuote_chainDisabled() public {
+        uint16 disabledChain = 65000;
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoter.ChainDisabled.selector, disabledChain));
+        executorQuoter.requestQuote(
+            disabledChain,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            RelayInstructions.encodeGas(250000, 0)
+        );
+    }
+
+    function test_requestQuote_unsupportedInstruction() public {
+        // Type 0xFF is not a valid instruction type
+        bytes memory badInstruction = hex"ff";
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoter.UnsupportedInstruction.selector, 0xff));
+        executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            badInstruction
+        );
+    }
+
+    function test_requestQuote_moreThanOneDropOff() public {
+        // Two Type 2 (drop-off) instructions
+        bytes memory twoDropOffs = abi.encodePacked(
+            RelayInstructions.encodeGasDropOffInstructions(1000, bytes32(uint256(uint160(address(this))))),
+            RelayInstructions.encodeGasDropOffInstructions(2000, bytes32(uint256(uint160(address(this)))))
+        );
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoter.MoreThanOneDropOff.selector));
+        executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            twoDropOffs
+        );
+    }
+
+    // Edge case tests for large values
+    //
+    // Note: The quote calculation uses uint128 * uint64 which fits in uint256 (2^192 < 2^256),
+    // so overflow is not possible with the current type constraints. These tests verify
+    // the contract handles extreme values correctly without reverting.
+    //
+    // Run with `forge test -vv` to see the actual quote values logged.
+
+    /// @notice Test that max uint128 gas limit is handled without overflow.
+    /// uint128 * uint64 = 2^192 max, which fits in uint256.
+    function test_requestQuote_maxGasLimit() public {
+        uint128 maxGas = type(uint128).max;
+        bytes memory relayInstructions = RelayInstructions.encodeGas(maxGas, 0);
+
+        uint256 quote = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+
+        // Log the actual values for inspection
+        emit log_named_uint("maxGasLimit input", maxGas);
+        emit log_named_uint("quote result", quote);
+        emit log_named_uint("quote in ETH (approx)", quote / 1e18);
+
+        assertGt(quote, maxGas, "Quote should be non-zero");
+    }
+
+    /// @notice Test that max uint128 msgValue is handled without overflow.
+    function test_requestQuote_maxMsgValue() public {
+        uint128 maxMsgValue = type(uint128).max;
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, maxMsgValue);
+
+        uint256 quote = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+
+        assertGt(quote, maxMsgValue, "Quote should be greater than u128.max");
+    }
+
+    /// @notice Test with extreme price values - all max uint64.
+    /// When srcPrice == dstPrice, conversion ratio is ~1, so no overflow.
+    function test_requestQuote_extremePrices() public {
+        ExecutorQuoter.Update[] memory extremeUpdates = new ExecutorQuoter.Update[](1);
+        extremeUpdates[0].chainId = DST_CHAIN;
+        extremeUpdates[0].update = packUint64(
+            type(uint64).max, // baseFee
+            type(uint64).max, // dstGasPrice
+            type(uint64).max, // srcPrice
+            type(uint64).max // dstPrice
+        );
+        executorQuoter.quoteUpdate(extremeUpdates);
+
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        uint256 quote = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+
+        emit log_named_uint("baseFee", type(uint64).max);
+        emit log_named_uint("dstGasPrice", type(uint64).max);
+        emit log_named_uint("srcPrice", type(uint64).max);
+        emit log_named_uint("dstPrice", type(uint64).max);
+        emit log_named_uint("gasLimit", 250000);
+        emit log_named_uint("quote result", quote);
+        emit log_named_uint("quote in ETH (approx)", quote / 1e18);
+
+        assertGt(quote, type(uint64).max, "Quote should be greater than a max price");
+    }
+
+    /// @notice Test quote with max msgValue AND max dropoff to verify they sum correctly.
+    function test_requestQuote_maxMsgValueAndDropoff() public {
+        uint128 maxGas = type(uint128).max;
+        uint128 maxMsgValue = type(uint128).max;
+        uint128 maxDropoff = type(uint128).max;
+
+        // Combine gas instruction (with max gas and max msgValue) + dropoff instruction
+        bytes memory relayInstructions = abi.encodePacked(
+            RelayInstructions.encodeGas(maxGas, maxMsgValue),
+            RelayInstructions.encodeGasDropOffInstructions(maxDropoff, bytes32(uint256(uint160(address(this)))))
+        );
+
+        uint256 quote = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+
+        emit log_named_uint("maxGas input", maxGas);
+        emit log_named_uint("maxMsgValue input", maxMsgValue);
+        emit log_named_uint("maxDropoff input", maxDropoff);
+        emit log_named_uint("quote result", quote);
+        emit log_named_uint("quote in ETH (approx)", quote / 1e18);
+        emit log_named_uint("type(uint256).max", type(uint256).max);
+        emit log_named_uint("type(uint128).max * 3", uint256(type(uint128).max) * 3);
+
+        // Verify quote is not capped at uint256 max (i.e., it's a real sum)
+        assertGt(quote, uint256(type(uint128).max), "Quote should be greater than a single max uint128");
+    }
+
+    /// @notice Compare individual quotes vs combined to verify addition.
+    function test_requestQuote_verifyAddition() public {
+        uint128 gasLimit = 250000;
+        uint128 msgValue = 1e18; // 1 ETH worth
+        uint128 dropoff = 2e18; // 2 ETH worth
+
+        // Get quote with just gas
+        bytes memory gasOnly = RelayInstructions.encodeGas(gasLimit, 0);
+        uint256 quoteGasOnly = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            gasOnly
+        );
+
+        // Get quote with gas + msgValue
+        bytes memory gasAndMsg = RelayInstructions.encodeGas(gasLimit, msgValue);
+        uint256 quoteGasAndMsg = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            gasAndMsg
+        );
+
+        // Get quote with gas + msgValue + dropoff
+        bytes memory all = abi.encodePacked(
+            RelayInstructions.encodeGas(gasLimit, msgValue),
+            RelayInstructions.encodeGasDropOffInstructions(dropoff, bytes32(uint256(uint160(address(this)))))
+        );
+        uint256 quoteAll = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            all
+        );
+
+        // Verify monotonic increase
+        assertGt(quoteGasAndMsg, quoteGasOnly, "Adding msgValue should increase quote");
+        assertGt(quoteAll, quoteGasAndMsg, "Adding dropoff should increase quote");
+    }
+
+    /// @notice Test quote calculation with zero prices (division by zero protection).
+    function test_requestQuote_zeroPrices() public {
+        // Set up a quote with zero srcPrice (would cause division by zero)
+        ExecutorQuoter.Update[] memory zeroUpdates = new ExecutorQuoter.Update[](1);
+        zeroUpdates[0].chainId = DST_CHAIN;
+        zeroUpdates[0].update = packUint64(
+            27971, // baseFee
+            100000000, // dstGasPrice
+            0, // srcPrice = 0 (division by zero)
+            35751300000000 // dstPrice
+        );
+        executorQuoter.quoteUpdate(zeroUpdates);
+
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        // Should revert on division by zero
+        vm.expectRevert();
+        executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+    }
+
+    /// @notice Test with zero gas limit - should return just base fee.
+    function test_requestQuote_zeroGasLimit() public view {
+        bytes memory relayInstructions = RelayInstructions.encodeGas(0, 0);
+
+        uint256 quote = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+
+        // With zero gas, quote should be just the normalized base fee
+        // baseFee = 27971 (in 10^10 decimals), normalized to 18 decimals
+        // 27971 * 10^(18-10) = 27971 * 10^8 = 2797100000000
+        require(quote >= 2797100000000, "Quote should include base fee");
+    }
+
+    /// @notice Test normalize function with from > to (division path).
+    /// This exercises the branch at line 107 where decimals are reduced.
+    function test_requestQuote_normalizeFromGreaterThanTo() public {
+        // Create a new quoter with SRC_TOKEN_DECIMALS = 8 (less than DECIMAL_RESOLUTION = 18)
+        // This will hit the from > to branch in normalize() at lines 183 and 187
+        ExecutorQuoter lowDecimalQuoter = new ExecutorQuoter(UPDATER, UPDATER, 8, bytes32(uint256(uint160(UPDATER))));
+
+        // Set up chain info
+        ExecutorQuoter.Update[] memory chainInfo = new ExecutorQuoter.Update[](1);
+        chainInfo[0].chainId = DST_CHAIN;
+        chainInfo[0].update = CHAIN_INFO_UPDATE_PACKED;
+        lowDecimalQuoter.chainInfoUpdate(chainInfo);
+
+        // Set up quote with non-zero values
+        ExecutorQuoter.Update[] memory quoteUpdates = new ExecutorQuoter.Update[](1);
+        quoteUpdates[0].chainId = DST_CHAIN;
+        quoteUpdates[0].update = packUint64(27971, 100000000, 35751300000000, 35751300000000);
+        lowDecimalQuoter.quoteUpdate(quoteUpdates);
+
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 1e18);
+
+        uint256 quote = lowDecimalQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+
+        // Quote should be non-zero and scaled down due to 8 decimals
+        assertGt(quote, 0, "Quote should be non-zero");
+    }
+
+    /// @notice Test normalize function with from == to (identity path).
+    /// This exercises the branch at line 111 where no scaling is needed.
+    function test_requestQuote_normalizeFromEqualsTo() public {
+        // Create a quoter with SRC_TOKEN_DECIMALS = 10 (equals QUOTE_DECIMALS)
+        // This will hit the from == to branch at line 174: normalize(baseFee, 10, 10)
+        ExecutorQuoter equalDecimalQuoter = new ExecutorQuoter(UPDATER, UPDATER, 10, bytes32(uint256(uint160(UPDATER))));
+
+        // Set up chain info with gasPriceDecimals = 18, nativeDecimals = 18
+        ExecutorQuoter.Update[] memory chainInfo = new ExecutorQuoter.Update[](1);
+        chainInfo[0].chainId = DST_CHAIN;
+        chainInfo[0].update = CHAIN_INFO_UPDATE_PACKED;
+        equalDecimalQuoter.chainInfoUpdate(chainInfo);
+
+        // Set up quote
+        ExecutorQuoter.Update[] memory quoteUpdates = new ExecutorQuoter.Update[](1);
+        quoteUpdates[0].chainId = DST_CHAIN;
+        quoteUpdates[0].update = packUint64(27971, 100000000, 35751300000000, 35751300000000);
+        equalDecimalQuoter.quoteUpdate(quoteUpdates);
+
+        // Use zero gas and zero msgValue to isolate the baseFee normalization
+        bytes memory relayInstructions = RelayInstructions.encodeGas(0, 0);
+
+        uint256 quote = equalDecimalQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            relayInstructions
+        );
+
+        // With SRC_TOKEN_DECIMALS = 10 = QUOTE_DECIMALS, baseFee should pass through unchanged
+        // baseFee = 27971
+        assertEq(quote, 27971, "Quote should equal baseFee when decimals match");
+    }
+
+    /// @notice Test requestExecutionQuote reverts when chain is disabled.
+    function test_requestExecutionQuote_chainDisabled() public {
+        uint16 disabledChain = 65000;
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoter.ChainDisabled.selector, disabledChain));
+        executorQuoter.requestExecutionQuote(
+            disabledChain,
+            DST_ADDR,
+            UPDATER,
+            ExecutorMessages.makeVAAv1Request(10002, bytes32(uint256(uint160(address(this)))), 1),
+            RelayInstructions.encodeGas(250000, 0)
+        );
+    }
 }

--- a/evm/test/ExecutorQuoter.t.sol
+++ b/evm/test/ExecutorQuoter.t.sol
@@ -181,7 +181,7 @@ contract ExecutorQuoterTest is Test {
         emit log_named_uint("quote result", quote);
         emit log_named_uint("quote in ETH (approx)", quote / 1e18);
 
-        assertGt(quote, maxGas, "Quote should be non-zero");
+        assertEq(quote, 34028236692093846346337460743176823942600000000, "Quote should match expected value");
     }
 
     /// @notice Test that max uint128 msgValue is handled without overflow.
@@ -197,7 +197,7 @@ contract ExecutorQuoterTest is Test {
             relayInstructions
         );
 
-        assertGt(quote, maxMsgValue, "Quote should be greater than u128.max");
+        assertEq(quote, 340282366920938463463374635228868211455, "Quote should match expected value");
     }
 
     /// @notice Test with extreme price values - all max uint64.
@@ -231,7 +231,7 @@ contract ExecutorQuoterTest is Test {
         emit log_named_uint("quote result", quote);
         emit log_named_uint("quote in ETH (approx)", quote / 1e18);
 
-        assertGt(quote, type(uint64).max, "Quote should be greater than a max price");
+        assertEq(quote, 1849286093389382549403750000, "Quote should match expected value for extreme prices");
     }
 
     /// @notice Test quote with max msgValue AND max dropoff to verify they sum correctly.
@@ -262,8 +262,7 @@ contract ExecutorQuoterTest is Test {
         emit log_named_uint("type(uint256).max", type(uint256).max);
         emit log_named_uint("type(uint128).max * 3", uint256(type(uint128).max) * 3);
 
-        // Verify quote is not capped at uint256 max (i.e., it's a real sum)
-        assertGt(quote, uint256(type(uint128).max), "Quote should be greater than a single max uint128");
+        assertEq(quote, 34028237372658580188214387669926038806136422910, "Quote should match expected value for max values");
     }
 
     /// @notice Test quote calculation with zero prices (division by zero protection).
@@ -307,7 +306,7 @@ contract ExecutorQuoterTest is Test {
         // With zero gas, quote should be just the normalized base fee
         // baseFee = 27971 (in 10^10 decimals), normalized to 18 decimals
         // 27971 * 10^(18-10) = 27971 * 10^8 = 2797100000000
-        require(quote >= 2797100000000, "Quote should include base fee");
+        assertEq(quote, 2797100000000, "Quote should equal normalized base fee");
     }
 
     /// @notice Test normalize function with from > to (division path).
@@ -339,8 +338,7 @@ contract ExecutorQuoterTest is Test {
             relayInstructions
         );
 
-        // Quote should be non-zero and scaled down due to 8 decimals
-        assertGt(quote, 0, "Quote should be non-zero");
+        assertEq(quote, 100002779, "Quote should match expected value for 8 decimal token");
     }
 
     /// @notice Test normalize function with from == to (identity path).

--- a/evm/test/ExecutorQuoterRouter.t.sol
+++ b/evm/test/ExecutorQuoterRouter.t.sol
@@ -7,6 +7,88 @@ import {RelayInstructions} from "../src/libraries/RelayInstructions.sol";
 import {Executor} from "../src/Executor.sol";
 import {ExecutorQuoter} from "../src/ExecutorQuoter.sol";
 import {ExecutorQuoterRouter} from "../src/ExecutorQuoterRouter.sol";
+import {IExecutorQuoter} from "../src/interfaces/IExecutorQuoter.sol";
+
+// Malicious refund receiver that attempts reentrancy
+contract ReentrantRefundReceiver {
+    ExecutorQuoterRouter public router;
+    uint256 public attackCount;
+    uint256 public maxAttacks;
+
+    uint16 public dstChain;
+    bytes32 public dstAddr;
+    address public quoterAddr;
+    bytes public requestBytes;
+    bytes public relayInstructions;
+
+    constructor(address _router) {
+        router = ExecutorQuoterRouter(_router);
+    }
+
+    function setAttackParams(
+        uint16 _dstChain,
+        bytes32 _dstAddr,
+        address _quoterAddr,
+        bytes memory _requestBytes,
+        bytes memory _relayInstructions,
+        uint256 _maxAttacks
+    ) external {
+        dstChain = _dstChain;
+        dstAddr = _dstAddr;
+        quoterAddr = _quoterAddr;
+        requestBytes = _requestBytes;
+        relayInstructions = _relayInstructions;
+        maxAttacks = _maxAttacks;
+    }
+
+    receive() external payable {
+        if (attackCount < maxAttacks) {
+            attackCount++;
+            // Attempt to re-enter requestExecution during refund
+            router.requestExecution{value: msg.value}(
+                dstChain,
+                dstAddr,
+                address(this),
+                quoterAddr,
+                requestBytes,
+                relayInstructions
+            );
+        }
+    }
+}
+
+// Contract that rejects ETH transfers (no receive or fallback)
+contract RefundRejecter {
+    // Intentionally no receive() or fallback() function
+}
+
+// Malicious quoter that returns manipulated values
+contract MaliciousQuoter is IExecutorQuoter {
+    uint256 public reportedPrice;
+    bytes32 public payeeAddress;
+
+    constructor(uint256 _reportedPrice, address _payee) {
+        reportedPrice = _reportedPrice;
+        payeeAddress = bytes32(uint256(uint160(_payee)));
+    }
+
+    function requestQuote(uint16, bytes32, address, bytes calldata, bytes calldata)
+        external
+        view
+        returns (uint256)
+    {
+        return reportedPrice;
+    }
+
+    function requestExecutionQuote(uint16, bytes32, address, bytes calldata, bytes calldata)
+        external
+        view
+        returns (uint256, bytes32, bytes32)
+    {
+        // Returns a low price but real payee gets the funds
+        return (reportedPrice, payeeAddress, bytes32(0));
+    }
+}
 
 contract ExecutorQuoterRouterTest is Test {
     Executor public executor;
@@ -157,6 +239,322 @@ contract ExecutorQuoterRouterTest is Test {
             testQuoter,
             ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1),
             RelayInstructions.encodeGas(250000, 0)
+        );
+    }
+
+    // Assertion-based tests
+
+    function test_quoteExecution_returnsCorrectValue() public view {
+        bytes memory requestBytes = ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1);
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        uint256 routerQuote = executorQuoterRouter.quoteExecution(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        uint256 directQuote = executorQuoter.requestQuote(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        assertEq(routerQuote, directQuote, "Router quote should match direct quoter quote");
+    }
+
+    function test_requestExecution_underpaid() public {
+        bytes memory requestBytes = ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1);
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        uint256 quote = executorQuoterRouter.quoteExecution(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoterRouter.Underpaid.selector, quote - 1, quote));
+        executorQuoterRouter.requestExecution{value: quote - 1}(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+    }
+
+    function test_requestExecution_paysPayee() public {
+        bytes memory requestBytes = ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1);
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        uint256 quote = executorQuoterRouter.quoteExecution(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        uint256 payeeBalanceBefore = testQuoter.balance;
+
+        executorQuoterRouter.requestExecution{value: quote}(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        assertEq(testQuoter.balance, payeeBalanceBefore + quote, "Payee should receive exact payment");
+    }
+
+    // Allow receiving refunds
+    receive() external payable {}
+
+    // Security tests
+
+    /// @notice Test that reentrancy during refund doesn't cause issues.
+    /// The current implementation does allow reentrancy, but it should not
+    /// cause loss of funds since state is read before the external call.
+    function test_reentrancy_duringRefund() public {
+        bytes memory requestBytes = ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1);
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        uint256 quote = executorQuoterRouter.quoteExecution(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        // Deploy reentrancy attacker
+        ReentrantRefundReceiver attacker = new ReentrantRefundReceiver(address(executorQuoterRouter));
+        attacker.setAttackParams(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            requestBytes,
+            relayInstructions,
+            2 // Try to reenter twice
+        );
+
+        // Fund the attacker with enough for multiple calls
+        uint256 excess = 1 ether;
+        uint256 totalFunding = (quote * 3) + excess;
+        vm.deal(address(attacker), totalFunding);
+
+        // Track payee balance before
+        uint256 payeeBalanceBefore = testQuoter.balance;
+
+        // Call from attacker context - the attacker will try to reenter on refund
+        vm.prank(address(attacker));
+        executorQuoterRouter.requestExecution{value: quote + excess}(
+            DST_CHAIN,
+            DST_ADDR,
+            address(attacker),
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        // Verify payee received correct payment (should be quote * 3 if reentrancy succeeded)
+        uint256 payeeBalanceAfter = testQuoter.balance;
+        uint256 totalPaid = payeeBalanceAfter - payeeBalanceBefore;
+
+        // Reentrancy should succeed (contract doesn't prevent it)
+        // attackCount should be 2 since maxAttacks = 2
+        assertEq(attacker.attackCount(), 2, "Reentrancy should occur twice");
+
+        // Each successful execution should pay the quote amount to payee
+        // Total paid should equal quote * (1 + attackCount)
+        uint256 expectedPayment = quote * (1 + attacker.attackCount());
+        assertEq(totalPaid, expectedPayment, "Payee should receive correct total payment");
+    }
+
+    /// @notice Test behavior with a malicious quoter that returns zero price.
+    function test_maliciousQuoter_zeroPrice() public {
+        address maliciousPayee = makeAddr("maliciousPayee");
+        MaliciousQuoter maliciousQuoter = new MaliciousQuoter(0, maliciousPayee);
+
+        // Register the malicious quoter
+        (address mallory, uint256 malloryPk) = makeAddrAndKey("mallory");
+        vm.prank(mallory);
+        executorQuoterRouter.updateQuoterContract(
+            makeAndSignGovernance(
+                OUR_CHAIN,
+                mallory,
+                bytes32(uint256(uint160(address(maliciousQuoter)))),
+                bytes32(uint256(uint160(mallory))),
+                malloryPk
+            )
+        );
+
+        bytes memory requestBytes = ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1);
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        // Quote returns 0
+        uint256 quote = executorQuoterRouter.quoteExecution(
+            DST_CHAIN,
+            DST_ADDR,
+            mallory,
+            mallory,
+            requestBytes,
+            relayInstructions
+        );
+        assertEq(quote, 0, "Malicious quoter should return 0");
+
+        // User sends 1 ether thinking it's a good deal, gets full refund
+        uint256 userBalanceBefore = address(this).balance;
+
+        executorQuoterRouter.requestExecution{value: 1 ether}(
+            DST_CHAIN,
+            DST_ADDR,
+            address(this),
+            mallory,
+            requestBytes,
+            relayInstructions
+        );
+
+        // User should get full refund since quote was 0
+        assertEq(address(this).balance, userBalanceBefore, "User should get full refund");
+        // Payee should receive 0
+        assertEq(maliciousPayee.balance, 0, "Malicious payee should receive 0");
+    }
+
+    /// @notice Test that quoter cannot steal funds by returning inconsistent values.
+    /// Even if requestQuote and requestExecutionQuote return different values,
+    /// the actual payment is based on requestExecutionQuote.
+    function test_maliciousQuoter_inconsistentQuotes() public {
+        // This quoter always returns a fixed low price
+        address maliciousPayee = makeAddr("maliciousPayee");
+        uint256 lowPrice = 100;
+        MaliciousQuoter maliciousQuoter = new MaliciousQuoter(lowPrice, maliciousPayee);
+
+        (address mallory, uint256 malloryPk) = makeAddrAndKey("mallory");
+        vm.prank(mallory);
+        executorQuoterRouter.updateQuoterContract(
+            makeAndSignGovernance(
+                OUR_CHAIN,
+                mallory,
+                bytes32(uint256(uint160(address(maliciousQuoter)))),
+                bytes32(uint256(uint160(mallory))),
+                malloryPk
+            )
+        );
+
+        bytes memory requestBytes = ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1);
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        uint256 userBalanceBefore = address(this).balance;
+
+        // User overpays significantly
+        executorQuoterRouter.requestExecution{value: 1 ether}(
+            DST_CHAIN,
+            DST_ADDR,
+            address(this),
+            mallory,
+            requestBytes,
+            relayInstructions
+        );
+
+        // User should get refund of (1 ether - lowPrice)
+        assertEq(address(this).balance, userBalanceBefore - lowPrice, "User should only pay the quoted price");
+        // Payee should receive exactly lowPrice
+        assertEq(maliciousPayee.balance, lowPrice, "Payee should receive exactly quoted price");
+    }
+
+    // Address validation tests (bytes32 with upper bits set)
+
+    /// @notice Test that governance rejects contract address with upper bits set.
+    function test_updateQuoterContract_nonEvmContractAddress() public {
+        (address alice, uint256 alicePk) = makeAddrAndKey("alice");
+        // Set upper bit of contract address (not a valid EVM address)
+        bytes32 badContractAddress = bytes32(uint256(1) << 255 | uint256(uint160(address(0x1234))));
+
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoterRouter.NotAnEvmAddress.selector, badContractAddress));
+        executorQuoterRouter.updateQuoterContract(
+            makeAndSignGovernance(OUR_CHAIN, alice, badContractAddress, SENDER_ADDRESS, alicePk)
+        );
+    }
+
+    /// @notice Test that governance rejects sender address with upper bits set.
+    function test_updateQuoterContract_nonEvmSenderAddress() public {
+        (address alice, uint256 alicePk) = makeAddrAndKey("alice");
+        // Set upper bit of sender address
+        bytes32 badSenderAddress = bytes32(uint256(1) << 255 | uint256(uint160(alice)));
+
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoterRouter.NotAnEvmAddress.selector, badSenderAddress));
+        executorQuoterRouter.updateQuoterContract(
+            makeAndSignGovernance(OUR_CHAIN, alice, UPDATE_IMPLEMENTATION, badSenderAddress, alicePk)
+        );
+    }
+
+    /// @notice Test address with just one bit set in upper 96 bits.
+    function test_updateQuoterContract_singleBitInUpperBytes() public {
+        (address alice, uint256 alicePk) = makeAddrAndKey("alice");
+        // Set bit 160 (first bit outside valid EVM address range)
+        bytes32 badAddress = bytes32(uint256(1) << 160 | uint256(uint160(address(0x1234))));
+
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoterRouter.NotAnEvmAddress.selector, badAddress));
+        executorQuoterRouter.updateQuoterContract(
+            makeAndSignGovernance(OUR_CHAIN, alice, badAddress, SENDER_ADDRESS, alicePk)
+        );
+    }
+
+    /// @notice Test that max valid EVM address (all 160 bits set) is accepted.
+    function test_updateQuoterContract_maxValidEvmAddress() public {
+        (address alice, uint256 alicePk) = makeAddrAndKey("alice");
+        // All 160 bits set = 0x00000000000000000000000ffffffffffffffffffffffffffffffffffffffff
+        bytes32 maxEvmAddress = bytes32(uint256(type(uint160).max));
+
+        // This should NOT revert due to address validation
+        // (may revert for other reasons like invalid signature if signer != quoter)
+        executorQuoterRouter.updateQuoterContract(
+            makeAndSignGovernance(OUR_CHAIN, alice, maxEvmAddress, SENDER_ADDRESS, alicePk)
+        );
+    }
+
+    /// @notice Test that RefundFailed is thrown when refund recipient rejects ETH.
+    function test_requestExecution_refundFailed() public {
+        // Deploy a contract that cannot receive ETH
+        RefundRejecter rejecter = new RefundRejecter();
+
+        bytes memory requestBytes = ExecutorMessages.makeVAAv1Request(OUR_CHAIN, bytes32(uint256(uint160(address(this)))), 1);
+        bytes memory relayInstructions = RelayInstructions.encodeGas(250000, 0);
+
+        uint256 quote = executorQuoterRouter.quoteExecution(
+            DST_CHAIN,
+            DST_ADDR,
+            testQuoter,
+            testQuoter,
+            requestBytes,
+            relayInstructions
+        );
+
+        // Overpay so a refund is attempted
+        uint256 overpayment = quote + 1 ether;
+
+        vm.expectRevert(abi.encodeWithSelector(ExecutorQuoterRouter.RefundFailed.selector, address(rejecter)));
+        executorQuoterRouter.requestExecution{value: overpayment}(
+            DST_CHAIN,
+            DST_ADDR,
+            address(rejecter), // refundAddr that rejects ETH
+            testQuoter,
+            requestBytes,
+            relayInstructions
         );
     }
 }


### PR DESCRIPTION
https://linear.app/wormholelabs/issue/CORE-1550/100percent-test-coverage-on-evm-and-validate-quoting-against-ts

Note that we do not actually need to rewrite the src contract for 100% coverage. The assembly is just not picked up by `--ir`. We can just provide the diff to whoever is reviewing the code.