### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/workflows/aptos.yml
+++ b/.github/workflows/aptos.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: aptos
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - run: sh ci.sh

--- a/.github/workflows/aptos.yml
+++ b/.github/workflows/aptos.yml
@@ -7,6 +7,8 @@ jobs:
   test:
     name: Aptos Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v7.2.0
     # https://github.com/aptos-labs/aptos-core/commit/35102f5f33c69b8e48e030243a09edad80cbd946
     container: aptoslabs/tools:devnet_35102f5f33c69b8e48e030243a09edad80cbd946@sha256:06503b21b53ad904c7d689c47a78259b4891fa0d1c6932550c784bddc0d3cda0
@@ -15,4 +17,6 @@ jobs:
         working-directory: aptos
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - run: sh ci.sh

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: evm
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -12,6 +12,8 @@ jobs:
 
     name: Foundry project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: evm
@@ -19,9 +21,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
         with:
           version: v1.3.6
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,10 +1,14 @@
 name: format
 on: pull_request
+permissions:
+  contents: read
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
       - run: bunx prettier --check .
@@ -12,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       # Pinned version of the v6 tag, which is a lightweight and hence mutable tag
       - uses: streetsidesoftware/cspell-action@214db1e3138f326d33b7a6a51c92852e89ab0618
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,7 +6,7 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -15,7 +15,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       # Pinned version of the v6 tag, which is a lightweight and hence mutable tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
         working-directory: svm/pinocchio
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: svm/pinocchio
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/sui.yml
+++ b/.github/workflows/sui.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: sui/executor
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - run: sui move test

--- a/.github/workflows/sui.yml
+++ b/.github/workflows/sui.yml
@@ -7,6 +7,8 @@ jobs:
   test:
     name: Sui Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # pushed Apr 8, 2025 at 4:10 pm
     container: mysten/sui-tools:sui-v1.46.0-release@sha256:c39b509328319dad3b73dbb4ae3a76d6c502f838b81f908fbc6a4e1da81c7855
     defaults:
@@ -14,4 +16,6 @@ jobs:
         working-directory: sui/executor
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - run: sui move test

--- a/.github/workflows/svm-anchor.yml
+++ b/.github/workflows/svm-anchor.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: svm/anchor
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Get solana version

--- a/.github/workflows/svm-anchor.yml
+++ b/.github/workflows/svm-anchor.yml
@@ -7,11 +7,15 @@ jobs:
   anchor-test:
     name: Anchor Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: svm/anchor
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Get solana version
         id: solana
         run: |

--- a/.github/workflows/svm-pinocchio.yml
+++ b/.github/workflows/svm-pinocchio.yml
@@ -7,15 +7,20 @@ jobs:
   pinocchio-test:
     name: Pinocchio Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: svm/pinocchio
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@98e1b82157cd469e843cb7f524c1313b4ad9492c # 1.88.0
         with:
-          components: rustfmt, clippy
+          persist-credentials: false
+      - name: Install Rust
+        run: |
+          rustup toolchain install 1.88.0
+          rustup default 1.88.0
+          rustup component add rustfmt clippy
       - name: Install Solana CLI
         run: |
           sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"

--- a/.github/workflows/svm-pinocchio.yml
+++ b/.github/workflows/svm-pinocchio.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: svm/pinocchio
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install Rust


### PR DESCRIPTION
## Summary

This PR fixes all zizmor security findings in the GitHub Actions workflow files.

## Findings Fixed

- **artipacked** (`.github/workflows/aptos.yml`): Added `persist-credentials: false` to `actions/checkout` step
- **excessive-permissions** (`.github/workflows/aptos.yml`): Added `permissions: contents: read` to `test` job
- **artipacked** (`.github/workflows/evm.yml`): Added `persist-credentials: false` to `actions/checkout` step
- **excessive-permissions** (`.github/workflows/evm.yml`): Added `permissions: contents: read` to `check` job
- **ref-version-mismatch** (`.github/workflows/evm.yml`): Updated version comment on `foundry-rs/foundry-toolchain` from `# v1` to `# v1.7.0`
- **artipacked** (`.github/workflows/format.yml`): Added `persist-credentials: false` to both `actions/checkout` steps (`prettier` and `spellcheck` jobs)
- **excessive-permissions** (`.github/workflows/format.yml`): Added `permissions: contents: read` at workflow level (covers both jobs)
- **artipacked** (`.github/workflows/publish.yml`): Added `persist-credentials: false` to `actions/checkout` step
- **artipacked** (`.github/workflows/sui.yml`): Added `persist-credentials: false` to `actions/checkout` step
- **excessive-permissions** (`.github/workflows/sui.yml`): Added `permissions: contents: read` to `test` job
- **artipacked** (`.github/workflows/svm-anchor.yml`): Added `persist-credentials: false` to `actions/checkout` step
- **excessive-permissions** (`.github/workflows/svm-anchor.yml`): Added `permissions: contents: read` to `anchor-test` job
- **artipacked** (`.github/workflows/svm-pinocchio.yml`): Added `persist-credentials: false` to `actions/checkout` step
- **excessive-permissions** (`.github/workflows/svm-pinocchio.yml`): Added `permissions: contents: read` to `pinocchio-test` job
- **superfluous-actions** (`.github/workflows/svm-pinocchio.yml`): Replaced `dtolnay/rust-toolchain` action with inline `rustup` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)